### PR TITLE
fix(parser): fix parent depth matching at root level

### DIFF
--- a/goconfigobj.go
+++ b/goconfigobj.go
@@ -160,16 +160,16 @@ func (co *ConfigObj) multiLineValue(value string, lines []string, curIndex, maxL
 }
 
 func (co *ConfigObj) matchParentSectDepth(sect *Section, depth int) *Section {
-	for {
-		if sect == nil || sect == sect.Parent() {
-			return nil
-		}
-
-		sect := sect.Parent()
-		if sect.Depth() == depth {
-			return sect.Parent()
-		}
+	if sect == nil || sect == sect.Parent() {
+		return nil
 	}
+
+	section := sect.Parent()
+	if section.Depth() == depth {
+		return section.Parent()
+	}
+
+	return co.matchParentSectDepth(section, depth)
 }
 
 //Section get section, if not have section, return nil

--- a/goconfigobj_test.go
+++ b/goconfigobj_test.go
@@ -114,6 +114,30 @@ func TestSectionDepth(t *testing.T) {
 	}
 }
 
+func TestSectionMultiDepth(t *testing.T) {
+	txt := `
+	aa = bb
+
+	[fff]
+		bb =gg
+		[[zz]]
+			[[["ggg"]]]
+				aa    =aa
+
+	[eee]
+		bb =gg
+		[[zz]]
+			[[["ggg"]]]
+			aa    =aa
+    `
+	co := NewConfigObj(strings.NewReader(txt))
+	if co.Value("aa") == "bb" && co.Section("fff").Section("zz").Section("ggg").Value("aa") == "aa" && co.Section("fff").Value("bb") == "gg" && co.Section("eee").Section("zz").Section("ggg").Value("aa") == "aa" && co.Section("eee").Value("bb") == "gg" {
+		t.Log("SectionMultiDepth test ok")
+	} else {
+		t.Error("SectionMultiDepth test failed")
+	}
+}
+
 func TestChinese(t *testing.T) {
 	txt := `
     [fff]


### PR DESCRIPTION
There was an infinite loop getting there are multiple sections at the root level.

This fixes the infinite loop.